### PR TITLE
Add visible dates to comments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -5,9 +5,9 @@ import java.time.LocalDate;
 public class Comment {
   private final String text;
   private final String author;
-  private final LocalDate timestamp;
+  private final String timestamp;
 
-  public Comment(String text, String author, LocalDate timestamp) {
+  public Comment(String text, String author, String timestamp) {
     this.text = text;
     this.author = author;
     this.timestamp = timestamp;
@@ -21,7 +21,7 @@ public class Comment {
     return this.author;
   }
 
-  public LocalDate getTimestamp() {
+  public String getTimestamp() {
     return this.timestamp;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -1,12 +1,13 @@
 package com.google.sps.data;
+import java.time.LocalDate;
 
 // Public immutable class representing a comment on a website
 public class Comment {
   private final String text;
   private final String author;
-  private final long timestamp;
+  private final LocalDate timestamp;
 
-  public Comment(String text, String author, long timestamp) {
+  public Comment(String text, String author, LocalDate timestamp) {
     this.text = text;
     this.author = author;
     this.timestamp = timestamp;
@@ -20,7 +21,7 @@ public class Comment {
     return this.author;
   }
 
-  public long getTimestamp() {
+  public LocalDate getTimestamp() {
     return this.timestamp;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -1,13 +1,12 @@
 package com.google.sps.data;
-import java.time.LocalDate;
 
 // Public immutable class representing a comment on a website
 public class Comment {
   private final String text;
   private final String author;
-  private final String timestamp;
+  private final long timestamp;
 
-  public Comment(String text, String author, String timestamp) {
+  public Comment(String text, String author, long timestamp) {
     this.text = text;
     this.author = author;
     this.timestamp = timestamp;
@@ -21,7 +20,7 @@ public class Comment {
     return this.author;
   }
 
-  public String getTimestamp() {
+  public long getTimestamp() {
     return this.timestamp;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -30,10 +30,8 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.sps.data.Comment;
-import java.time.LocalDate;
-import java.time.Instant;
-import java.time.ZoneId;
-
+import java.text.SimpleDateFormat;
+import java.sql.Date;
 
 /** Servlet that handles comments data */
 @WebServlet("/data")
@@ -50,9 +48,10 @@ public class DataServlet extends HttpServlet {
     PreparedQuery results = datastore.prepare(query);
     for (Entity entity : results.asIterable()) {
       /* Convert the comment's timestamp (ms since Epoch) to a date (d/m/y) */
-      LocalDate commentDate = Instant.ofEpochMilli(
-        (long)entity.getProperty("timestamp"))
-        .atZone(ZoneId.systemDefault()).toLocalDate();
+      SimpleDateFormat sdf = new java.text.SimpleDateFormat("MMMM d, yyyy");
+      sdf.setTimeZone(java.util.TimeZone.getTimeZone("GMT-4")); /*EDT*/
+      String commentDate = sdf.format(
+        new Date((long)entity.getProperty("timestamp")));
 
       Comment comment = new Comment((String)entity.getProperty("text"),
           (String)entity.getProperty("author"), commentDate);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -30,9 +30,6 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.sps.data.Comment;
-import java.text.SimpleDateFormat;
-import java.sql.Date;
-import java.util.TimeZone;
 
 /** Servlet that handles comments data */
 @WebServlet("/data")
@@ -49,15 +46,9 @@ public class DataServlet extends HttpServlet {
     PreparedQuery results = datastore.prepare(query);
 
     for (Entity entity : results.asIterable()) {
-      /* Convert the comment's timestamp (ms since Epoch) to a date (d/m/y) */
-      SimpleDateFormat sdf = new java.text.SimpleDateFormat("MMMM d, yyyy");
-      sdf.setTimeZone(java.util.TimeZone.getTimeZone(
-        TimeZone.getDefault().toString()));
-      String commentDate = sdf.format(
-        new Date((long)entity.getProperty("timestamp")));
-
       Comment comment = new Comment((String)entity.getProperty("text"),
-          (String)entity.getProperty("author"), commentDate);
+          (String)entity.getProperty("author"), 
+          (long)entity.getProperty("timestamp"));
       comments.add(comment);
     }
     

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -30,6 +30,9 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.sps.data.Comment;
+import java.time.LocalDate;
+import java.time.Instant;
+import java.time.ZoneId;
 
 
 /** Servlet that handles comments data */
@@ -46,9 +49,13 @@ public class DataServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
     for (Entity entity : results.asIterable()) {
+      /* Convert the comment's timestamp (ms since Epoch) to a date (d/m/y) */
+      LocalDate commentDate = Instant.ofEpochMilli(
+        (long)entity.getProperty("timestamp"))
+        .atZone(ZoneId.systemDefault()).toLocalDate();
+
       Comment comment = new Comment((String)entity.getProperty("text"),
-          (String)entity.getProperty("author"), 
-          (long)entity.getProperty("timestamp"));
+          (String)entity.getProperty("author"), commentDate);
       comments.add(comment);
     }
     

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -32,6 +32,7 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.sps.data.Comment;
 import java.text.SimpleDateFormat;
 import java.sql.Date;
+import java.util.TimeZone;
 
 /** Servlet that handles comments data */
 @WebServlet("/data")
@@ -46,10 +47,12 @@ public class DataServlet extends HttpServlet {
       "timestamp", SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
+
     for (Entity entity : results.asIterable()) {
       /* Convert the comment's timestamp (ms since Epoch) to a date (d/m/y) */
       SimpleDateFormat sdf = new java.text.SimpleDateFormat("MMMM d, yyyy");
-      sdf.setTimeZone(java.util.TimeZone.getTimeZone("GMT-4")); /*EDT*/
+      sdf.setTimeZone(java.util.TimeZone.getTimeZone(
+        TimeZone.getDefault().toString()));
       String commentDate = sdf.format(
         new Date((long)entity.getProperty("timestamp")));
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -110,7 +110,11 @@ function createComment(comment) {
   commentSignature.className = "signature";
 
   commentText.innerText = comment.text; 
-  commentSignature.innerText = `${comment.author}  (${comment.timestamp})`;
+
+  const dateTimeFormat = new Intl.DateTimeFormat('en', { year: 'numeric', month: 'long', day: 'numeric' }) 
+  const [{ value: month },,{ value: day },,{ value: year }] = dateTimeFormat 
+    .formatToParts(new Date(comment.timestamp) ) ;
+  commentSignature.innerText = `${comment.author}  (${month} ${day}, ${year})`;
 
   commentHolder.appendChild(commentText);
   commentHolder.appendChild(commentSignature);

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -100,9 +100,6 @@ function getGuestBook() {
   })
 }
 
-const months = ['January', 'February', 'March', 'April', 'May', 'June', 
-    'July', 'August', 'September', 'October', 'November', 'December'];
-
 function createComment(comment) {
   const commentHolder = document.createElement('div');
   const commentText = document.createElement('p');
@@ -113,8 +110,7 @@ function createComment(comment) {
   commentSignature.className = "signature";
 
   commentText.innerText = comment.text; 
-  const commentDate = comment.timestamp;
-  commentSignature.innerText = `${comment.author}  (${months[commentDate.month-1]} ${commentDate.day}, ${commentDate.year})`;
+  commentSignature.innerText = `${comment.author}  (${comment.timestamp})`;
 
   commentHolder.appendChild(commentText);
   commentHolder.appendChild(commentSignature);

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -65,7 +65,7 @@ function checkShowMore() {
     let text = window.location.href.split("#").pop()
     showMore(text);
 
-    /*If the user got to the anchor via a dropdown, the focus is now on that
+    /* If the user got to the anchor via a dropdown, the focus is now on that
     dropdown link. But it should be on the hidden text itself instead, so we'll 
     move it. */
     document.getElementById(text).focus();
@@ -92,25 +92,34 @@ function getGuestBook() {
   const guestBook = document.getElementById('guest-book-comments');
   fetch("/data").then(response => response.json()).then((comments) => {
     comments.forEach((comment) => {
-      const commentHolder = document.createElement('div');
-      const commentText = document.createElement('p');
-      const commentAuthor = document.createElement('p');
-      
-      commentHolder.className = "comment";
-      commentText.className = "message";
-      commentAuthor.className = "author";
-
-      commentText.innerText = comment.text; 
-      commentAuthor.innerText = comment.author;
-
-      commentHolder.appendChild(commentText);
-      commentHolder.appendChild(commentAuthor);
-      guestBook.appendChild(commentHolder);
-      guestBook.appendChild(document.createElement('br'));
+      guestBook.appendChild(createComment(comment));
+      guestBook.appendChild(document.createElement('br')); 
+        /* Add break before next comment - one extra at the end is actually
+        good, makes it easier to scroll down to read the last comment */
     });
   })
 }
 
+const months = ['January', 'February', 'March', 'April', 'May', 'June', 
+    'July', 'August', 'September', 'October', 'November', 'December'];
+
+function createComment(comment) {
+  const commentHolder = document.createElement('div');
+  const commentText = document.createElement('p');
+  const commentSignature = document.createElement('p');
+  
+  commentHolder.className = "comment";
+  commentText.className = "message";
+  commentSignature.className = "signature";
+
+  commentText.innerText = comment.text; 
+  const commentDate = comment.timestamp;
+  commentSignature.innerText = `${comment.author}  (${months[commentDate.month-1]} ${commentDate.day}, ${commentDate.year})`;
+
+  commentHolder.appendChild(commentText);
+  commentHolder.appendChild(commentSignature);
+  return commentHolder;
+}
 
 /**
  * Adds a random fact to the page. Deprecated.

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -107,8 +107,8 @@
   content: "\"";
 }
 
-.author::before {
-  content: "  — "; /*two long spaces before em-dash*/
+.signature::before {
+  content: "  — "; /* two long spaces before em-dash */
 }
 
 a:link, 


### PR DESCRIPTION
https://shulijones-step-2020.appspot.com/index.html
Take the comments' timestamps, convert to date format, and append to the end of each comment signature.

The style I was going for is a "guest book" style as opposed to an "internet comments" style, which is why I list the date but not the time each comment was left. (As a sidenote, I think the timezone might be slightly off, as a comment I made at 10:45 pm EDT June 30th was recorded as being made on July 1st. But it's relying on the system timezone, so I'm not sure if there's a great fix for that. Happy to take ideas.)