### PR TITLE
Implement image upload using Blobstore

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-translate</artifactId>
-      <version>1.70.0</version>
+      <version>1.95.0</version>
     </dependency>
 </dependencies>
 

--- a/portfolio/src/main/java/com/google/sps/servlets/BlobstoreUploadUrlServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/BlobstoreUploadUrlServlet.java
@@ -1,0 +1,26 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet that returns a URL allowing users to upload files to Blobstore.
+ */
+@WebServlet("/blobstore-upload-url")
+public class BlobstoreUploadUrlServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    BlobstoreService blobstoreService = 
+        BlobstoreServiceFactory.getBlobstoreService();
+    String uploadUrl = blobstoreService.createUploadUrl("/image-handler");
+
+    response.setContentType("text/html");
+    response.getWriter().println(uploadUrl);
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/BlobstoreUploadUrlServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/BlobstoreUploadUrlServlet.java
@@ -18,6 +18,9 @@ public class BlobstoreUploadUrlServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     BlobstoreService blobstoreService = 
         BlobstoreServiceFactory.getBlobstoreService();
+    // We link the upload URL Blobstore generates to /image-handler so that 
+    // whenever a blob is sent to the URL, after Blobstore processes it,
+    // it will redirect to /image-handler so we can save it in Datastore
     String uploadUrl = blobstoreService.createUploadUrl("/image-handler");
 
     response.setContentType("text/html");

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -23,8 +23,7 @@ public class DeleteDataServlet extends HttpServlet {
     if (!password.equals("shuli-super-secret-password")) {
       jsonResponse.addProperty("errorMessage", "Incorrect password.");
       response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-    }
-    else {
+    } else {
       response.setStatus(HttpServletResponse.SC_OK);
       DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
       Query query = new Query("Comment");

--- a/portfolio/src/main/java/com/google/sps/servlets/ImageHandlerServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ImageHandlerServlet.java
@@ -1,0 +1,84 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.blobstore.BlobInfo;
+import com.google.appengine.api.blobstore.BlobInfoFactory;
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.appengine.api.images.ImagesService;
+import com.google.appengine.api.images.ImagesServiceFactory;
+import com.google.appengine.api.images.ServingUrlOptions;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+
+/**
+ * Servlet to process image upload requests using the URL that Blobstore gives.
+ */
+@WebServlet("/image-handler")
+public class ImageHandlerServlet extends HttpServlet {
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    long timestamp = System.currentTimeMillis();
+    String imageUrl = getUploadedFileUrl(request, "image");
+
+    // Store image in datastore
+    Entity imageEntity = new Entity("Image");
+    imageEntity.setProperty("imageUrl", imageUrl);
+    imageEntity.setProperty("author", ""); //TODO
+    imageEntity.setProperty("timestamp", timestamp);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.put(imageEntity);
+
+    response.sendRedirect("/index.html");
+  }
+
+  /** Returns a URL that points to the uploaded file, or null if the user didn't upload a file. */
+  private String getUploadedFileUrl(HttpServletRequest request, String formInputElementName) {
+    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+    Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
+    List<BlobKey> blobKeys = blobs.get("image");
+
+    // User submitted form without selecting a file, so we can't get a URL. (dev server)
+    if (blobKeys == null || blobKeys.isEmpty()) { 
+      return null; 
+    }
+
+    // index.html only contains a single file input, so get the first index.
+    BlobKey blobKey = blobKeys.get(0);
+
+    // User submitted form without selecting a file, so we can't get a URL. (live server)
+    BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
+    if (blobInfo.getSize() == 0) {
+      blobstoreService.delete(blobKey);
+      return null;
+    }
+
+    // TODO: check the validity of the file here, e.g. to make sure it's an image file
+    // https://stackoverflow.com/q/10779564/873165
+
+    // Use ImagesService to get a URL that points to the uploaded file.
+    ImagesService imagesService = ImagesServiceFactory.getImagesService();
+    ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
+
+    // Get relative path to the image rather than the original one,
+    // which names a specific host.
+    try {
+      URL url = new URL(imagesService.getServingUrl(options));
+      return url.getPath();
+    } catch (MalformedURLException e) {
+      return imagesService.getServingUrl(options);
+    }
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/ImageServerServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ImageServerServlet.java
@@ -1,0 +1,28 @@
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.annotation.WebServlet;
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+
+/**
+ * Servlet that returns a Blobstore image based on its key.
+ */
+@WebServlet("/image-server")
+public class ImageServerServlet extends HttpServlet {
+    private BlobstoreService blobstoreService =   
+      BlobstoreServiceFactory.getBlobstoreService();
+
+    @Override
+    public void doGet(HttpServletRequest req, HttpServletResponse res)
+        throws IOException {
+            BlobKey blobKey = new BlobKey(req.getParameter("blob-key"));
+            // The serve request returns a special message telling AppEngine to 
+            // replace it with the blob (image) with this blobKey
+            blobstoreService.serve(blobKey, res);
+        }
+}

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -9,7 +9,7 @@
     <script src="script.js"></script>
   </head>
 
-  <body onload="getGuestBook()">
+  <body onload="getGuestBook();loadBlobstoreAndForm()">
     <!-- Header stored only in one place (script.js) for dryness -->
     <div id="header">
       <script> 
@@ -40,6 +40,16 @@
         <textarea name="name" maxlength="100" placeholder="Your name" required></textarea>
         <br>
         <textarea name="message" maxlength="3000" placeholder="Message for me" required></textarea>
+        <br>
+        <input type="submit">
+      </form>
+      <br>
+      <form id="image-submit" class="hidden" method="POST" enctype="multipart/form-data">
+        <label for="guestbook-pics">Send in a fun picture, if you'd like!</label>
+        <br>
+        <input type=file name="image" id="guestbook-pics" required>
+        <br>
+        <textarea name="name" maxlength="100" placeholder="Your name" required></textarea>
         <br>
         <input type="submit">
       </form>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -143,7 +143,7 @@ function formatAndTranslateDate(epochDate, lang) {
     .formatToParts(new Date(epochDate) );
   return `${month} ${day}, ${year}`;
 }
-c
+
 /**
  * Deletes all guestbook comments from the website if the 
  * correct password is entered.
@@ -172,6 +172,21 @@ function deleteData() {
       }
     });
   });
+}
+
+/**
+ * Loads the blobstore image storage and shows the form to submit an image.
+ */
+function loadBlobstoreAndForm() {
+  fetch('/blobstore-upload-url')
+      .then((response) => {
+        return response.text();
+      })
+      .then((imageUploadUrl) => {
+        const messageForm = document.getElementById('image-submit');
+        messageForm.action = imageUploadUrl;
+        messageForm.classList.remove('hidden');
+      });
 }
 
 /**

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -179,13 +179,12 @@ function deleteData() {
  */
 function loadBlobstoreAndForm() {
   fetch('/blobstore-upload-url')
-      .then((response) => {
-        return response.text();
-      })
-      .then((imageUploadUrl) => {
+      .then((response) => response.text())
+      .then((uploadUrl) => { 
         const messageForm = document.getElementById('image-submit');
-        messageForm.action = imageUploadUrl;
-        messageForm.classList.remove('hidden');
+        //Make it so that submitting the image form will redirect to Blobstore's upload URL
+        messageForm.action = uploadUrl; 
+        messageForm.classList.remove('hidden'); //Show image form now that it's ready
       });
 }
 


### PR DESCRIPTION
https://shulijones-step-2020.appspot.com/index.html
Implement basic image upload using Blobstore.

Showing the uploaded images is not yet implemented, but just accepting and saving them on Datastore represents quite a bit of code. After uploading, the home page should reload and look like it did before. (Note: most of this code is taken from or based on the example code, and is not fully original. I did go through and add more comments.)

My first commit to this PR followed the walkthrough and used imagesService.getServingUrl to store the blob. Previous STEP interns discovered that that does not work while deployed, so I switched to using blobstoreService.store, following this tutorial: https://cloud.google.com/appengine/docs/standard/java/blobstore#Serving_a_blob