### PR TITLE
Implement FindMeetingQuery

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
@@ -16,6 +16,7 @@ package com.google.sps;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -27,6 +28,26 @@ public final class Event {
   private final String title;
   private final TimeRange when;
   private final Set<String> attendees = new HashSet<>();
+
+  /**
+   * A comparator for sorting events by their start time in ascending order.
+   */
+  public static final Comparator<Event> ORDER_BY_START_TIME = new Comparator<Event>() {
+    @Override
+    public int compare(Event a, Event b) {
+      return Long.compare(a.getWhen().start(), b.getWhen().start());
+    }
+  };
+
+  /**
+   * A comparator for sorting events by their end time in ascending order.
+   */
+  public static final Comparator<Event> ORDER_BY_END_TIME = new Comparator<Event>() {
+    @Override
+    public int compare(Event a, Event b) {
+      return Long.compare(a.getWhen().end(), b.getWhen().end());
+    }
+  };
 
   /**
    * Creates a new event.

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
@@ -28,14 +27,13 @@ public final class FindMeetingQuery {
     long longDuration = request.getDuration();
     ArrayList<TimeRange> possibleTimes = new ArrayList<TimeRange>();
 
-    // Deal with special cases:
-    // Meeting is too long, impossible to ever hold it
+    // Check if meeting can fit within a day (otherwise impossible to hold it)
     if (longDuration > TimeRange.WHOLE_DAY.duration()) {
       return possibleTimes;
     }
-    // No events/no attendees, hold meeting anytime
-    if (events.size() == 0 || attendees.size() == 0) {
-      possibleTimes.add(TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.WHOLE_DAY.duration()));
+    // No attendees, hold meeting anytime
+    if (attendees.isEmpty()) {
+      possibleTimes.add(TimeRange.WHOLE_DAY);
       return possibleTimes;
     }
  
@@ -44,96 +42,67 @@ public final class FindMeetingQuery {
 
     // Filter events so that it only includes events that have one or more
     // attendees who are coming to this event
-    ArrayList<Event> eventsByStart = new ArrayList<Event>();
-    for (Event event : events) {
-      HashSet<String> eventAttendees = new HashSet<String>(event.getAttendees());
-      HashSet<String> meetingAttendees = new HashSet<String>(attendees);
-      eventAttendees.retainAll(meetingAttendees); // set intersection
-      if (eventAttendees.size() > 0) {
-        eventsByStart.add(event);
-      }
-    }
+    List<Event> eventsByStart = new ArrayList<>(getRelevantEvents(attendees, events));
     Collections.sort(eventsByStart, Event.ORDER_BY_START_TIME);   
 
-    // Check again to see if there are any events
-    if (eventsByStart.size() == 0 ) {
-      possibleTimes.add(TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.WHOLE_DAY.duration()));
+    // If there are no events including our meeting attendees, can hold anytime
+    if (eventsByStart.isEmpty() ) {
+      possibleTimes.add(TimeRange.WHOLE_DAY);
       return possibleTimes;
     }
 
     // Check if we can have a meeting before the earliest-starting event
     int earliestStart = eventsByStart.get(0).getWhen().start();
-    if (TimeRange.START_OF_DAY < earliestStart && earliestStart - TimeRange.START_OF_DAY >= duration) {
+    if (TimeRange.START_OF_DAY < earliestStart && 
+      earliestStart - TimeRange.START_OF_DAY >= duration) {
       possibleTimes.add(TimeRange.fromStartEnd(
           TimeRange.START_OF_DAY, earliestStart, false));
     }
 
-    // Check in between events - we know we can't have anything until
-    // the earliest-starting event ends, so find the earliest-starting event
-    // after that end time and see if the meeting fits between them
-    Event currentEarliestEvent = eventsByStart.get(0);
-    Event nextEvent;
-    while (true) {
-      // Try to get event
-      Optional<Event> potentialNextEvent = getNextEarliestEvent(
-          currentEarliestEvent.getWhen().end(), eventsByStart, 0, eventsByStart.size()-1);
+    // Check in between events
+    Event currentEvent = eventsByStart.get(0);
+    int latestEnd = currentEvent.getWhen().end();
 
-      if (!potentialNextEvent.isPresent()) { 
-        break; // No event starts after current one ends
-      }
-
-      // Check if we can fit the meeting between the two events
-      // ***BUG***
-      nextEvent = potentialNextEvent.get();
+    for (int i = 1; i < eventsByStart.size(); i++) {
+      Event nextEvent = eventsByStart.get(i);
+      int nextEventEnd = nextEvent.getWhen().end();
       int nextEventStart = nextEvent.getWhen().start();
-      int currentEventEnd = currentEarliestEvent.getWhen().end();
+      int currentEventEnd = currentEvent.getWhen().end();
+
+      if (nextEventEnd < latestEnd) {
+        continue; //there is still another event ongoing
+      }
+      latestEnd = nextEventEnd;
+
       if (nextEventStart - currentEventEnd >= duration) {
         possibleTimes.add(TimeRange.fromStartEnd(
             currentEventEnd, nextEventStart, false));
       }
-      currentEarliestEvent = nextEvent;
+      currentEvent = nextEvent;
     }
 
 
-    // Lastly, check if we can have a meeting before the latest-ending event
-    ArrayList<Event> eventsByEnd = new ArrayList<Event>(eventsByStart);
-    Collections.sort(eventsByEnd, Event.ORDER_BY_END_TIME);
-    int latestEventEnd = eventsByEnd.get(eventsByEnd.size()-1).getWhen().end();
-    if (TimeRange.END_OF_DAY - latestEventEnd >= duration) {
+    // Lastly, see if we can have a meeting between the last event end and the end of the day
+    if (TimeRange.END_OF_DAY - latestEnd >= duration) {
       possibleTimes.add(TimeRange.fromStartEnd(
-        latestEventEnd, TimeRange.END_OF_DAY, true));
+        latestEnd, TimeRange.END_OF_DAY, true));
     }
 
     return possibleTimes;
   }
 
-  // Parameters: int endTime, representing a time in minutes 
-  //     List<Event>, a list of events which must be already sorted by start time
-  //     ints low and high, marking off the section of list of events to be searched
-  // Returns: the earliest-starting event that starts at or after endTime,
-  // or an empty optional if there is no such event listed
-  private Optional<Event> getNextEarliestEvent(int endTime, 
-      List<Event> events, int low, int high) {
-    
-    // Base cases
-    if (events.get(low).getWhen().start() >= endTime) {
-      // The first event is the earliest, so if it works, we're done
-      return Optional.of(events.get(low));
+  // Given a list of events and a list of attendees, return a filtered list
+  // of events such that all events have at least one attendee from attendees
+  private Collection<Event> getRelevantEvents(Collection<String> attendees, Collection<Event> events) {
+    ArrayList<Event> filteredEvents = new ArrayList<Event>();
+    for (Event event : events) {
+      HashSet<String> eventAttendees = new HashSet<String>(event.getAttendees());
+      HashSet<String> meetingAttendees = new HashSet<String>(attendees);
+      eventAttendees.retainAll(meetingAttendees); // set intersection
+      if (!eventAttendees.isEmpty()) {
+        filteredEvents.add(event);
+      }
     }
-    if (low == high || events.get(high).getWhen().start() < endTime) {
-      // If low == high, only one event (which we know doesn't work
-      // or we'd have returned already); if latest-starting event 
-      // doesn't work, we know none will
-      return Optional.empty();
-    }
-
-    // Neither of our base cases conditions are met, 
-    // so binary search the list recursively
-    int mid = (low + high) / 2;
-    if (events.get(mid).getWhen().start() < endTime) {
-      return getNextEarliestEvent(endTime, events, mid+1, high);
-    } else {
-      return getNextEarliestEvent(endTime, events, low, mid);
-    }
+    return filteredEvents;
   }
-}
+} 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,10 +14,126 @@
 
 package com.google.sps;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    ArrayList<String> attendees = new ArrayList<String>(request.getAttendees());
+    long longDuration = request.getDuration();
+    ArrayList<TimeRange> possibleTimes = new ArrayList<TimeRange>();
+
+    // Deal with special cases:
+    // Meeting is too long, impossible to ever hold it
+    if (longDuration > TimeRange.WHOLE_DAY.duration()) {
+      return possibleTimes;
+    }
+    // No events/no attendees, hold meeting anytime
+    if (events.size() == 0 || attendees.size() == 0) {
+      possibleTimes.add(TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.WHOLE_DAY.duration()));
+      return possibleTimes;
+    }
+ 
+    // Since we know longDuration is less than one day, it can fit in an int
+    int duration = (int)longDuration;
+
+    // Filter events so that it only includes events that have one or more
+    // attendees who are coming to this event
+    ArrayList<Event> eventsByStart = new ArrayList<Event>();
+    for (Event event : events) {
+      HashSet<String> eventAttendees = new HashSet<String>(event.getAttendees());
+      HashSet<String> meetingAttendees = new HashSet<String>(attendees);
+      eventAttendees.retainAll(meetingAttendees); // set intersection
+      if (eventAttendees.size() > 0) {
+        eventsByStart.add(event);
+      }
+    }
+    Collections.sort(eventsByStart, Event.ORDER_BY_START_TIME);   
+
+    // Check again to see if there are any events
+    if (eventsByStart.size() == 0 ) {
+      possibleTimes.add(TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.WHOLE_DAY.duration()));
+      return possibleTimes;
+    }
+
+    // Check if we can have a meeting before the earliest-starting event
+    int earliestStart = eventsByStart.get(0).getWhen().start();
+    if (TimeRange.START_OF_DAY < earliestStart && earliestStart - TimeRange.START_OF_DAY >= duration) {
+      possibleTimes.add(TimeRange.fromStartEnd(
+          TimeRange.START_OF_DAY, earliestStart, false));
+    }
+
+    // Check in between events - we know we can't have anything until
+    // the earliest-starting event ends, so find the earliest-starting event
+    // after that end time and see if the meeting fits between them
+    Event currentEarliestEvent = eventsByStart.get(0);
+    Event nextEvent;
+    while (true) {
+      // Try to get event
+      Optional<Event> potentialNextEvent = getNextEarliestEvent(
+          currentEarliestEvent.getWhen().end(), eventsByStart, 0, eventsByStart.size()-1);
+
+      if (!potentialNextEvent.isPresent()) { 
+        break; // No event starts after current one ends
+      }
+
+      // Check if we can fit the meeting between the two events
+      // ***BUG***
+      nextEvent = potentialNextEvent.get();
+      int nextEventStart = nextEvent.getWhen().start();
+      int currentEventEnd = currentEarliestEvent.getWhen().end();
+      if (nextEventStart - currentEventEnd >= duration) {
+        possibleTimes.add(TimeRange.fromStartEnd(
+            currentEventEnd, nextEventStart, false));
+      }
+      currentEarliestEvent = nextEvent;
+    }
+
+
+    // Lastly, check if we can have a meeting before the latest-ending event
+    ArrayList<Event> eventsByEnd = new ArrayList<Event>(eventsByStart);
+    Collections.sort(eventsByEnd, Event.ORDER_BY_END_TIME);
+    int latestEventEnd = eventsByEnd.get(eventsByEnd.size()-1).getWhen().end();
+    if (TimeRange.END_OF_DAY - latestEventEnd >= duration) {
+      possibleTimes.add(TimeRange.fromStartEnd(
+        latestEventEnd, TimeRange.END_OF_DAY, true));
+    }
+
+    return possibleTimes;
+  }
+
+  // Parameters: int endTime, representing a time in minutes 
+  //     List<Event>, a list of events which must be already sorted by start time
+  //     ints low and high, marking off the section of list of events to be searched
+  // Returns: the earliest-starting event that starts at or after endTime,
+  // or an empty optional if there is no such event listed
+  private Optional<Event> getNextEarliestEvent(int endTime, 
+      List<Event> events, int low, int high) {
+    
+    // Base cases
+    if (events.get(low).getWhen().start() >= endTime) {
+      // The first event is the earliest, so if it works, we're done
+      return Optional.of(events.get(low));
+    }
+    if (low == high || events.get(high).getWhen().start() < endTime) {
+      // If low == high, only one event (which we know doesn't work
+      // or we'd have returned already); if latest-starting event 
+      // doesn't work, we know none will
+      return Optional.empty();
+    }
+
+    // Neither of our base cases conditions are met, 
+    // so binary search the list recursively
+    int mid = (low + high) / 2;
+    if (events.get(mid).getWhen().start() < endTime) {
+      return getNextEarliestEvent(endTime, events, mid+1, high);
+    } else {
+      return getNextEarliestEvent(endTime, events, low, mid);
+    }
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -40,10 +40,13 @@ public final class FindMeetingQueryTest {
   private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
+  private static final int TIME_0945AM = TimeRange.getTimeInMinutes(9, 45);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
+  private static final int TIME_1045AM = TimeRange.getTimeInMinutes(10, 45);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
   private static final int DURATION_30_MINUTES = 30;
+  private static final int DURATION_45_MINUTES = 45;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
   private static final int DURATION_1_HOUR = 60;
@@ -146,6 +149,36 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void threeOverlappingEvents() {
+    // Have three events overlapping. There should only be two options.
+    //
+    // Events  :       |--A-|
+    //                     |--B--|
+    //                          |--B--|
+    // Day     : |--------------------------|
+    // Options : |--1--|              |--2--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_45_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0945AM,
+        DURATION_60_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            TimeRange.fromStartEnd(TIME_1045AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  } 
 
   @Test
   public void nestedEvents() {


### PR DESCRIPTION
Update: an edited version of this function that passes all tests.
I replied to and resolved all the comments where I made the suggested change. However, I had to manually click the brown "refresh" button (not just refresh the page) to have them look resolved, so if they are still visible and getting in your way, I'd recommend doing so as well.

-------
This passes all tests except the one I just added.

I've labelled where I think the bug occurs, around line 85 of FindMeetingQuery - you can search for it by searching "BUG". To explain: my algorithm searches for time blocks to hold meetings by taking an event, finding the next event that happens after it (the earliest-starting event that starts after the first one ends), and seeing if the meeting can fit in between those two events. 

Here's the situation my added test addresses: say there are three events, where A starts earlier and then overlaps with B, and B starts earlier and then overlaps with C. When my algorithm considers A, it will not find B, since B starts before A ends. But it will find C, since C starts after A ends. If there is space between A and C to schedule a meeting, my algorithm will do so, because it does not know that it is scheduling the meeting at the same time as B.

I'm very interested in hearing what you think - if this is indeed a case my algorithm and the given tests don't address, or if there's something off with my line of reasoning. I'm pretty sure I know how to fix my algorithm, but I think that if it passes the tests while broken, then the tests should be expanded.